### PR TITLE
Update DetourNavMeshQuery.cpp

### DIFF
--- a/Detour/Source/DetourNavMeshQuery.cpp
+++ b/Detour/Source/DetourNavMeshQuery.cpp
@@ -711,8 +711,6 @@ dtStatus dtNavMeshQuery::findNearestPoly(const float* center, const float* exten
 										 dtPolyRef* nearestRef, float* nearestPt) const
 {
 	dtAssert(m_nav);
-
-	*nearestRef = 0;
 	
 	// Get nearby polygons from proximity grid.
 	const int MAX_SEARCH = 128;


### PR DESCRIPTION
fix the Segment fault when "nearestRef" is NULL
